### PR TITLE
Add contact forms and update playlist

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -281,3 +281,33 @@ footer p {
     font-size: 3rem;
   }
 }
+
+/* Contact Form */
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+  margin-top: 1rem;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.contact-form button {
+  padding: 0.5rem 1rem;
+  background-color: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.contact-form button:hover {
+  background-color: #6d8138;
+}

--- a/index-en.html
+++ b/index-en.html
@@ -110,7 +110,7 @@
     <h2>Listen & Watch</h2>
     <div class="media-embed">
       <iframe
-        src="https://open.spotify.com/embed/playlist/4e0Gn3Dr8eGCo3wzNOJn60"
+        src="https://open.spotify.com/embed/playlist/7mhgYWMUVLKnpceCPE7KLG?si=27d095fb53e64abd"
         width="300" height="380"
         frameborder="0" allow="encrypted-media">
       </iframe>
@@ -129,6 +129,33 @@
     <h2>Contact & Booking</h2>
     <p>Email: <a href="mailto:konfetti.partyband@gmail.com">konfetti.partyband@gmail.com</a></p>
     <p>Phone: +46 76 213 95 33 (Eliot Petrén)</p>
+    <form class="contact-form" action="mailto:konfetti.partyband@gmail.com" method="post" enctype="text/plain">
+      <label for="name-en">Name</label>
+      <input type="text" id="name-en" name="Name" required>
+
+      <label for="email-en">Email</label>
+      <input type="email" id="email-en" name="Email" required>
+
+      <label for="phone-en">Phone Number</label>
+      <input type="tel" id="phone-en" name="Phone" required>
+
+      <label for="event-type-en">Type of event</label>
+      <select id="event-type-en" name="Event Type">
+        <option value="Wedding">Wedding</option>
+        <option value="Company Event">Company Event</option>
+        <option value="Birthday Party">Birthday Party</option>
+        <option value="Festival">Festival</option>
+        <option value="Other">Other</option>
+      </select>
+
+      <label for="event-date-en">Event Date</label>
+      <input type="date" id="event-date-en" name="Date">
+
+      <label for="description-en">Description</label>
+      <textarea id="description-en" name="Description" rows="4"></textarea>
+
+      <button type="submit">Send</button>
+    </form>
   </section>
 
   <!-- Footer -->

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
     <h2>Lyssna & se</h2>
     <div class="media-embed">
       <!-- Spotify och YouTube inbäddning -->
-      <iframe src="https://open.spotify.com/embed/playlist/4e0Gn3Dr8eGCo3wzNOJn60?si=12670f3525b646dc" width="300"
+      <iframe src="https://open.spotify.com/embed/playlist/7mhgYWMUVLKnpceCPE7KLG?si=27d095fb53e64abd" width="300"
         height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
       <iframe width="300" height="169" src="https://www.youtube.com/embed/v7nJJm3A0NA" frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -128,7 +128,33 @@
     <h2>Kontakt & bokning</h2>
     <p>E-post: <a href="mailto:konfetti.partyband@gmail.com">konfetti.partyband@gmail.com</a></p>
     <p>Telefon: 076 - 213 95 33 (Eliot Petrén)</p>
-    <!-- I POC-fasen räcker mailto-länk; senare kan du lägga in riktigt formulär -->
+    <form class="contact-form" action="mailto:konfetti.partyband@gmail.com" method="post" enctype="text/plain">
+      <label for="name">Namn</label>
+      <input type="text" id="name" name="Namn" required>
+
+      <label for="email">E-post</label>
+      <input type="email" id="email" name="E-post" required>
+
+      <label for="phone">Telefonnummer</label>
+      <input type="tel" id="phone" name="Telefon" required>
+
+      <label for="event-type">Typ av event</label>
+      <select id="event-type" name="Eventtyp">
+        <option value="Bröllop">Bröllop</option>
+        <option value="Företagsevent">Företagsevent</option>
+        <option value="Födelsedagsfest">Födelsedagsfest</option>
+        <option value="Festival">Festival</option>
+        <option value="Annat">Annat</option>
+      </select>
+
+      <label for="event-date">Datum för event</label>
+      <input type="date" id="event-date" name="Datum">
+
+      <label for="description">Beskrivning</label>
+      <textarea id="description" name="Beskrivning" rows="4"></textarea>
+
+      <button type="submit">Skicka</button>
+    </form>
   </section>
 
   <!-- Footer -->


### PR DESCRIPTION
## Summary
- replace Spotify playlist on both pages
- add booking contact forms with inputs for name, email, phone, event type, date, and description
- style the contact form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e6a6aa398832794fbd03f39ef5e8d