### PR TITLE
Add collapsible gallery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -225,6 +225,9 @@ p {
   grid-template-rows: repeat(3, 1fr);
   column-gap: 1rem;
   row-gap: 1rem;
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.5s ease;
 }
 
 @media (min-width: 544px) {
@@ -269,6 +272,21 @@ p {
   padding: 0.5rem;
   border-radius: 4px;
   cursor: pointer;
+}
+
+#gallery-toggle {
+  display: block;
+  margin: 0 auto 1rem;
+  background-color: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#gallery-toggle:hover {
+  opacity: 0.9;
 }
 
 .contact-form button:hover {

--- a/index-en.html
+++ b/index-en.html
@@ -141,6 +141,7 @@
   <!-- Gallery -->
   <section id="gallery" class="container">
     <h2>Gallery</h2>
+    <button id="gallery-toggle" data-open-text="Show images" data-close-text="Hide images">Show images</button>
     <div class="gallery-grid"></div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
   <!-- Galleri Sektion -->
   <section id="gallery" class="container">
     <h2>Galleri</h2>
+    <button id="gallery-toggle" data-open-text="Visa bilder" data-close-text="Dölj bilder">Visa bilder</button>
     <div class="gallery-grid"></div>
   </section>
 

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -3,6 +3,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof galleryImages === 'undefined') return;
   const grid = document.querySelector('.gallery-grid');
   if (!grid) return;
+  const toggleBtn = document.getElementById('gallery-toggle');
+  const openText = toggleBtn ? toggleBtn.dataset.openText : '';
+  const closeText = toggleBtn ? toggleBtn.dataset.closeText : '';
 
   galleryImages.forEach(src => {
     const a = document.createElement('a');
@@ -13,4 +16,21 @@ document.addEventListener('DOMContentLoaded', () => {
     a.appendChild(img);
     grid.appendChild(a);
   });
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      if (grid.classList.contains('open')) {
+        grid.style.maxHeight = '0';
+        grid.classList.remove('open');
+        toggleBtn.textContent = openText;
+      } else {
+        grid.style.maxHeight = grid.scrollHeight + 'px';
+        grid.classList.add('open');
+        toggleBtn.textContent = closeText;
+      }
+    });
+    // Ensure closed state on load
+    grid.style.maxHeight = '0';
+    toggleBtn.textContent = openText;
+  }
 });


### PR DESCRIPTION
## Summary
- add toggle button for the gallery
- style the collapsible gallery with animations
- implement JS to expand/collapse the gallery

## Testing
- `node scripts/generateGallery.js`

------
https://chatgpt.com/codex/tasks/task_e_6863f2fbbd108327888bed268a595a17